### PR TITLE
Multiplier support & comment(Description field) instead of profile ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ ecl-profiles:
      start-year: 2020
      end-year: 2030
      
+  profile_comment_in_stea:
+     ecl-key: FWPT
+     mult: 1.1
+
+  another_profile_comment_in_stea:
+     ecl-key: FWPT
+     mult: [ 1.1, 2, 0 ]  
+ 
 # When you use the ecl-profiles keyword to update profiles feteched directly 
 # from an eclipse simulation you also need to set the ecl-case keyword to
 # point to an existing eclipse summary case on disk

--- a/stea/__init__.py
+++ b/stea/__init__.py
@@ -67,20 +67,31 @@ def calculate(stea_input):
                                  stea_input.project_version,
                                  stea_input.config_date)
     request = SteaRequest(stea_input, project)
-
+  
     for profile_id, profile_data in stea_input.ecl_profiles.iteritems():
-        ecl_key = profile_data[SteaInputKeys.ECL_KEY]
-        start_year = profile_data.get(SteaInputKeys.START_YEAR)
-        end_year = profile_data.get(SteaInputKeys.END_YEAR)
-
-        request.add_ecl_profile(profile_id, ecl_key, first_year=start_year, last_year=end_year)
+        if not profile_id in project.profiles:
+          profile_list=[k for k,v in project.profiles.items() if ('Description' in v and v['Description']==profile_id)]
+        else:
+          profile_list=[profile_id]
+        if len(profile_list)>0:
+          ecl_key = profile_data[SteaInputKeys.ECL_KEY]
+          mult = profile_data.get(SteaInputKeys.ECL_MULT)
+          start_year = profile_data.get(SteaInputKeys.START_YEAR)
+          end_year = profile_data.get(SteaInputKeys.END_YEAR)
+          for pid in profile_list:
+            request.add_ecl_profile(pid, ecl_key, first_year=start_year, last_year=end_year, multiplier=mult)
 
 
     for profile_id, profile_data in stea_input.profiles.iteritems():
-        start_year = profile_data.get(SteaInputKeys.START_YEAR)
-        data = profile_data.get(SteaInputKeys.DATA)
-
-        request.add_profile(profile_id, start_year, data)
+        if not profile_id in project.profiles:
+          profile_list=[k for k,v in project.profiles.items() if ('Description' in v and v['Description']==profile_id)]
+        else:
+          profile_list=[profile_id]
+        if len(profile_list)>0:
+          start_year = profile_data.get(SteaInputKeys.START_YEAR)
+          data = profile_data.get(SteaInputKeys.DATA)
+          for pid in profile_list:
+            request.add_profile(pid, start_year, data)
 
     return SteaResult(client.calculate(request), stea_input)
 

--- a/stea/__init__.py
+++ b/stea/__init__.py
@@ -84,14 +84,14 @@ def calculate(stea_input):
 
     for profile_id, profile_data in stea_input.profiles.iteritems():
         if not profile_id in project.profiles:
-          profile_list=[k for k,v in project.profiles.items() if ('Description' in v and v['Description']==profile_id)]
+            profile_list=[k for k,v in project.profiles.items() if ('Description' in v and v['Description']==profile_id)]
         else:
-          profile_list=[profile_id]
+            profile_list=[profile_id]
         if len(profile_list)>0:
-          start_year = profile_data.get(SteaInputKeys.START_YEAR)
-          data = profile_data.get(SteaInputKeys.DATA)
-          for pid in profile_list:
-            request.add_profile(pid, start_year, data)
+            start_year = profile_data.get(SteaInputKeys.START_YEAR)
+            data = profile_data.get(SteaInputKeys.DATA)
+            for pid in profile_list:
+                request.add_profile(pid, start_year, data)
 
     return SteaResult(client.calculate(request), stea_input)
 

--- a/stea/__init__.py
+++ b/stea/__init__.py
@@ -70,7 +70,7 @@ def calculate(stea_input):
   
     for profile_id, profile_data in stea_input.ecl_profiles.iteritems():
         if not profile_id in project.profiles:
-          profile_list=[k for k,v in project.profiles.items() if ('Description' in v and v['Description']==profile_id)]
+          profile_list=[k for k,v in project.profiles.items() if v.get(SteaInputKeys.PROFILE_KEY)==profile_id]
         else:
           profile_list=[profile_id]
         if len(profile_list)>0:
@@ -84,7 +84,7 @@ def calculate(stea_input):
 
     for profile_id, profile_data in stea_input.profiles.iteritems():
         if not profile_id in project.profiles:
-            profile_list=[k for k,v in project.profiles.items() if ('Description' in v and v['Description']==profile_id)]
+            profile_list=[k for k,v in project.profiles.items() if v.get(SteaInputKeys.PROFILE_KEY)==profile_id]
         else:
             profile_list=[profile_id]
         if len(profile_list)>0:

--- a/stea/stea_keys.py
+++ b/stea/stea_keys.py
@@ -41,3 +41,4 @@ class SteaInputKeys(object):
     END_YEAR        = "end-year"
     PROFILES        = "profiles"
     DATA            = "data"
+    PROFILE_KEY     = "Description"

--- a/stea/stea_keys.py
+++ b/stea/stea_keys.py
@@ -35,6 +35,7 @@ class SteaInputKeys(object):
     ECL_PROFILES    = "ecl-profiles"
     ECL_CASE        = "ecl-case"
     ECL_KEY         = "ecl-key"
+    ECL_MULT        = "mult"		
     SERVER          = "stea-server"
     START_YEAR      = "start-year"
     END_YEAR        = "end-year"

--- a/stea/stea_request.py
+++ b/stea/stea_request.py
@@ -1,6 +1,7 @@
 import datetime
 import types
 from .stea_keys import SteaKeys
+import sys
 
 def date_string(dt):
     return dt.strftime("%Y-%m-%dT%H:%M:%S")
@@ -71,7 +72,12 @@ class SteaRequest(object):
 
         unit = self.project.get_profile_unit(profile_id)
         mult = self.project.get_profile_mult(profile_id)
-        unit_conversion = self.units[unit][ecl_unit] * self.scale_factors[mult]
+        if unit in self.units and ecl_unit in self.units[unit]:  
+          unitfactor = self.units[unit][ecl_unit]
+        else:
+          unitfactor = 1.0
+          sys.stdout.write('Default conversion between %s and %s to 1.\n' % (unit, ecl_unit))
+        unit_conversion = unitfactor * self.scale_factors[mult]
         data = list(case.blocked_production(key, time_range) * unit_conversion)
         if isinstance(multiplier, types.ListType):
           ni=min(len(multiplier),len(data))

--- a/stea/stea_request.py
+++ b/stea/stea_request.py
@@ -73,16 +73,16 @@ class SteaRequest(object):
         unit = self.project.get_profile_unit(profile_id)
         mult = self.project.get_profile_mult(profile_id)
         if unit in self.units and ecl_unit in self.units[unit]:  
-          unitfactor = self.units[unit][ecl_unit]
+            unitfactor = self.units[unit][ecl_unit]
         else:
-          unitfactor = 1.0
-          sys.stdout.write('Default conversion between %s and %s to 1.\n' % (unit, ecl_unit))
+            unitfactor = 1.0
+            sys.stdout.write('Default conversion between %s and %s to 1.\n' % (unit, ecl_unit))
         unit_conversion = unitfactor * self.scale_factors[mult]
         data = list(case.blocked_production(key, time_range) * unit_conversion)
         if isinstance(multiplier, types.ListType):
-          ni=min(len(multiplier),len(data))
-          data[:ni]=map(lambda x,y:x*y,data[:ni],multiplier[:ni])
+            ni=min(len(multiplier),len(data))
+            data[:ni]=map(lambda x,y:x*y,data[:ni],multiplier[:ni])
         else:
-          data = [x*multiplier for x in data]
+            data = [x*multiplier for x in data]
         self.add_profile(profile_id, first_year, data)
 

--- a/stea/stea_request.py
+++ b/stea/stea_request.py
@@ -1,4 +1,5 @@
 import datetime
+import types
 from .stea_keys import SteaKeys
 
 def date_string(dt):
@@ -44,7 +45,7 @@ class SteaRequest(object):
         return self.request_data
 
 
-    def add_ecl_profile(self, profile_id, key, first_year=None, last_year=None):
+    def add_ecl_profile(self, profile_id, key, first_year=None, last_year=None, multiplier=None):
         if self.stea_input.ecl_case is None:
             raise ValueError("When adding ecl_profile you must configure an Eclipse case")
 
@@ -60,6 +61,9 @@ class SteaRequest(object):
             end_date = case.end_date
             last_year = end_date.year
 
+        if multiplier is None:
+            multiplier = 1.0
+
         start_time = datetime.datetime(first_year, 1, 1)
         end_time = datetime.datetime(last_year + 1, 1,1)
         time_range = case.time_range(start=start_time, end=end_time, interval="1Y")
@@ -68,6 +72,11 @@ class SteaRequest(object):
         unit = self.project.get_profile_unit(profile_id)
         mult = self.project.get_profile_mult(profile_id)
         unit_conversion = self.units[unit][ecl_unit] * self.scale_factors[mult]
-        data = case.blocked_production(key, time_range) * unit_conversion
-        self.add_profile(profile_id, first_year, list(data))
+        data = list(case.blocked_production(key, time_range) * unit_conversion)
+        if isinstance(multiplier, types.ListType):
+          ni=min(len(multiplier),len(data))
+          data[:ni]=map(lambda x,y:x*y,data[:ni],multiplier[:ni])
+        else:
+          data = [x*multiplier for x in data]
+        self.add_profile(profile_id, first_year, data)
 

--- a/tests/test_stea.py
+++ b/tests/test_stea.py
@@ -70,9 +70,10 @@ class SteaTest(unittest.TestCase):
 
     def setUp(self):
         self.project_id = 4872
-        self.project_version = 1
+        self.project_version = 3
         self.config_date = datetime.datetime(2018, 6, 26, 11, 0 , 0)
-        self.fopt_profile_id = "b709ad66-54de-4424-8834-b644d0d68e09"
+        self.fopt_profile_id = "28558281-b82d-42a2-88a5-ba8e3e7d150d"
+        self.fopt_profile_id_desc = "FOPT"
         self.test_server = test_server
         if online():
             self.client = SteaClient(self.test_server)
@@ -280,6 +281,55 @@ class SteaTest(unittest.TestCase):
         self.assertIn("NPV", res)
         self.assertEqual(res["NPV"], 456)
 
+
+    @unittest.skipUnless(online(), "Must be on statoil network")
+    def test_mult(self):
+        with TestAreaContext("stea_request"):
+            case = create_case()
+            case.fwrite()
+            with open("config_file","w") as f:
+                f.write("{}: {}\n".format(SteaInputKeys.CONFIG_DATE, self.config_date))
+                f.write("{}: {}\n".format(SteaInputKeys.PROJECT_ID, self.project_id))
+                f.write("{}: {}\n".format(SteaInputKeys.PROJECT_VERSION, self.project_version))
+                f.write("{}: \n".format(SteaInputKeys.ECL_PROFILES))
+                f.write("   {}: \n".format(self.fopt_profile_id))
+                f.write("      {}: FOPT\n".format(SteaInputKeys.ECL_KEY))
+                f.write("      {}: [2,1]\n".format(SteaInputKeys.ECL_MULT))
+                f.write("{}: {}\n".format(SteaInputKeys.SERVER, test_server))
+                f.write("{}: \n".format(SteaInputKeys.RESULTS))
+                f.write("   - NPV\n")
+                f.write("{}: {}\n".format(SteaInputKeys.ECL_CASE, "CSV"))
+
+            stea_input = SteaInput(["config_file"])
+            results = calculate(stea_input)
+        res = results.results(SteaKeys.CORPORATE)
+        self.assertEqual(len(res), 1)
+        self.assertIn("NPV", res)
+        self.assertEqual(res["NPV"], 536.1371967150193)
+
+    @unittest.skipUnless(online(), "Must be on statoil network")
+    def test_desc(self):
+        with TestAreaContext("stea_request"):
+            case = create_case()
+            case.fwrite()
+            with open("config_file","w") as f:
+                f.write("{}: {}\n".format(SteaInputKeys.CONFIG_DATE, self.config_date))
+                f.write("{}: {}\n".format(SteaInputKeys.PROJECT_ID, self.project_id))
+                f.write("{}: {}\n".format(SteaInputKeys.PROJECT_VERSION, self.project_version))
+                f.write("{}: \n".format(SteaInputKeys.ECL_PROFILES))
+                f.write("   {}: \n".format(self.fopt_profile_id_desc))
+                f.write("      {}: FOPT\n".format(SteaInputKeys.ECL_KEY))
+                f.write("{}: {}\n".format(SteaInputKeys.SERVER, test_server))
+                f.write("{}: \n".format(SteaInputKeys.RESULTS))
+                f.write("   - NPV\n")
+                f.write("{}: {}\n".format(SteaInputKeys.ECL_CASE, "CSV"))
+
+            stea_input = SteaInput(["config_file"])
+            results = calculate(stea_input)
+        res = results.results(SteaKeys.CORPORATE)
+        self.assertEqual(len(res), 1)
+        self.assertIn("NPV", res)
+        self.assertEqual(res["NPV"], 536.1371967150193)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
added support for multipliers (Scalar or lists)

Comment (Description) field in STEA database can be used instead of profile_id. this is mapped to profile_id via GET results.